### PR TITLE
Fix macOS build, resolve clippy warnings, add Windows ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
             target: i686-pc-windows-msvc
             bin: gbscraper.exe
             final: gbscraper-windows-i686.zip
+          - os_name: Windows-aarch64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+            bin: gbscraper.exe
+            final: gbscraper-windows-aarch64.zip
           - os_name: macOS-x86_64
             os: macOS-latest
             target: x86_64-apple-darwin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.24" , features = ["derive"] }
 serde_json = { version = "1.0.122" }
 clap = { version = "4.5.13", features = ["derive"] }
 bitflags = "2.6.0"
-zip = "2.1.6"
+zip = { version = "2.2.0", default-features = false, features = ["deflate-miniz"] }
 image = "0.25.2"
 sanitise-file-name = "1.0.0"
 time = "0.3.36"

--- a/src/lib/scraper/batching.rs
+++ b/src/lib/scraper/batching.rs
@@ -15,7 +15,7 @@ pub fn download_period(url: &str, dest: &str, options: &mut ScraperOptions) -> i
         println!("Attemping download of period page with url: {url}");
     }
 
-    for issue_url in get_issue_urls_in_period(&url, &options)? {
+    for issue_url in get_issue_urls_in_period(&url, options)? {
         if let Err(x) = download_issue(&issue_url, dest, options) {
             eprintln!("Error downloading issue {issue_url}: {}", x);
         }
@@ -31,7 +31,7 @@ pub fn download_all(url: &str, dest: &str, options: &mut ScraperOptions) -> io::
         println!("Attemping download of base page with url: {url}");
     }
 
-    for period_url in get_period_urls(&url, &options)? {
+    for period_url in get_period_urls(&url, options)? {
         if let Err(x) = download_period(&period_url, dest, options) {
             eprintln!("Error downloading period {period_url}: {}", x);
         }
@@ -43,7 +43,7 @@ pub fn download_all(url: &str, dest: &str, options: &mut ScraperOptions) -> io::
 pub fn get_period_urls(url: &str, options: &ScraperOptions) -> io::Result<Vec<String>> {
     let mut ret = Vec::new();
 
-    let res = try_download(&url, options.download_attempts)?;
+    let res = try_download(url, options.download_attempts)?;
     let body = res.text().to_result()?;
 
     let doc = Html::parse_document(&body);
@@ -72,7 +72,7 @@ pub fn get_period_urls(url: &str, options: &ScraperOptions) -> io::Result<Vec<St
 pub fn get_issue_urls_in_period(url: &str, options: &ScraperOptions) -> io::Result<Vec<String>> {
     let mut ret = Vec::new();
 
-    let res = try_download(&url, options.download_attempts)?;
+    let res = try_download(url, options.download_attempts)?;
     let body = res.text().to_result()?;
     let doc = Html::parse_document(&body);
 

--- a/src/lib/scraper/batching.rs
+++ b/src/lib/scraper/batching.rs
@@ -12,7 +12,7 @@ pub fn download_period(url: &str, dest: &str, options: &mut ScraperOptions) -> i
     let url = sanitize_url(url)?;
 
     if options.verbose {
-        println!("Attemping download of period page with url: {url}");
+        println!("Attempting download of period page with url: {url}");
     }
 
     for issue_url in get_issue_urls_in_period(&url, options)? {
@@ -28,7 +28,7 @@ pub fn download_all(url: &str, dest: &str, options: &mut ScraperOptions) -> io::
     let url = sanitize_url(url)?;
 
     if options.verbose {
-        println!("Attemping download of base page with url: {url}");
+        println!("Attempting download of base page with url: {url}");
     }
 
     for period_url in get_period_urls(&url, options)? {

--- a/src/lib/scraper/helpers.rs
+++ b/src/lib/scraper/helpers.rs
@@ -46,7 +46,7 @@ pub(crate) fn sanitize_url(url: &str) -> io::Result<String> {
     }
 }
 
-// Methods to convert between option/result types for error propogation.
+// Methods to convert between option/result types for error propagation.
 
 pub(crate) trait ToResult<T> {
     fn to_result(self) -> std::io::Result<T>;

--- a/src/lib/scraper/helpers.rs
+++ b/src/lib/scraper/helpers.rs
@@ -69,7 +69,7 @@ impl<T> ToResultErrorMessage<T> for Option<T> {
     fn to_result(self, msg: &str) -> std::io::Result<T> {
         match self {
             Some(x) => Ok(x),
-            None => Err(std::io::Error::other(msg)),
+            None => Err(std::io::Error::other(msg.to_string())),
         }
     }
 }

--- a/src/lib/scraper/helpers.rs
+++ b/src/lib/scraper/helpers.rs
@@ -14,7 +14,7 @@ pub(crate) fn id_from_url(url: &str) -> io::Result<String> {
         None => url_obj
             .path_segments()
             .to_result(INVALID_URL)?
-            .last()
+            .next_back()
             .to_result(INVALID_URL)?
             .to_string(),
     })
@@ -41,7 +41,7 @@ pub(crate) fn sanitize_url(url: &str) -> io::Result<String> {
     const PERIOD_TAG: &str = "atm_aiy";
     let url_obj = Url::try_from(url).to_result()?;
     match url_obj.query_pairs().find(|x| x.0 == PERIOD_TAG) {
-        Some(x) => Ok(std::format!("{base_url}&{PERIOD_TAG}={}", x.1.to_string())),
+        Some(x) => Ok(std::format!("{base_url}&{PERIOD_TAG}={}", x.1)),
         None => Ok(base_url),
     }
 }
@@ -49,7 +49,6 @@ pub(crate) fn sanitize_url(url: &str) -> io::Result<String> {
 // Methods to convert between option/result types for error propogation.
 
 pub(crate) trait ToResult<T> {
-    ///
     fn to_result(self) -> std::io::Result<T>;
 }
 
@@ -57,13 +56,12 @@ impl<T, E: Display> ToResult<T> for std::result::Result<T, E> {
     fn to_result(self) -> std::io::Result<T> {
         match self {
             Ok(x) => Ok(x),
-            Err(x) => Err(std::io::Error::new(io::ErrorKind::Other, x.to_string())),
+            Err(x) => Err(std::io::Error::other(x.to_string())),
         }
     }
 }
 
 pub(crate) trait ToResultErrorMessage<T> {
-    ///
     fn to_result(self, msg: &str) -> std::io::Result<T>;
 }
 
@@ -71,19 +69,14 @@ impl<T> ToResultErrorMessage<T> for Option<T> {
     fn to_result(self, msg: &str) -> std::io::Result<T> {
         match self {
             Some(x) => Ok(x),
-            None => Err(std::io::Error::new(io::ErrorKind::Other, msg)),
+            None => Err(std::io::Error::other(msg)),
         }
     }
 }
 
 /// Generate filename for image.
 pub(crate) fn generate_image_filename(page_number: &usize, page_id: &str, ext: &str) -> String {
-    std::format!(
-        "{0}-{1}.{2}",
-        std::format!("{:0>5}", page_number),
-        page_id,
-        ext
-    )
+    std::format!("{:0>5}-{page_id}.{ext}", page_number)
 }
 
 /// Determine image extension by the content header.
@@ -109,7 +102,7 @@ pub(crate) fn get_image_ext(res: &reqwest::blocking::Response) -> io::Result<Str
 /// Determine image extension by the content header.
 pub(crate) fn try_download(url: &str, mut attempts: u32) -> io::Result<reqwest::blocking::Response> {
     let indefinite = attempts == 0;
-    let mut res: io::Result<reqwest::blocking::Response> = Err(io::Error::new(io::ErrorKind::Other, ""));
+    let mut res: io::Result<reqwest::blocking::Response> = Err(io::Error::other(""));
     while indefinite || attempts > 0 {
         res = reqwest::blocking::get(url).to_result();
         if let Ok(res) = res {

--- a/src/lib/scraper/mod.rs
+++ b/src/lib/scraper/mod.rs
@@ -1,5 +1,6 @@
 pub mod batching;
 mod helpers;
+#[allow(clippy::module_inception)]
 pub mod scraper;
 pub mod types;
 

--- a/src/lib/scraper/scraper.rs
+++ b/src/lib/scraper/scraper.rs
@@ -73,7 +73,7 @@ pub fn download_issue(
 
     // Check if image directory and any needed formats already exist on disk.
 
-    let mut formats = options.formats.clone();
+    let mut formats = options.formats;
     let exists_already = std::path::Path::new(&issue_pics_dir).exists();
 
     if std::path::Path::new(&filename_pdf).exists() {
@@ -129,7 +129,7 @@ pub fn download_issue(
     let mut first_page = "1".to_string();
     let mut i_page = 1;
     for page in issue.page {
-        if let None = page.src {
+        if page.src.is_none() {
             page_number_lookup.insert(page.pid.clone(), i_page);
             pages_to_download.push_back(page.pid.clone());
             if i_page == 1 {
@@ -172,12 +172,8 @@ pub fn download_issue(
         // Download images linked in JSON.
         // Note: JSON will contain an entry for every page in book. Requested page should have accompanying source URL, and adjacent pages may as well.
         for page in &issue.page {
-            // Skip if already downloaded.
-            if let None = &page.src {
-                continue;
-            }
-            // Skip if no download link.
-            else if pages_downloaded.contains(&page.pid) {
+            // Skip if no download link or already downloaded.
+            if page.src.is_none() || pages_downloaded.contains(&page.pid) {
                 continue;
             }
 
@@ -209,8 +205,8 @@ pub fn download_issue(
 
                     let mut any_png = false;
                     let mut canvas = image::DynamicImage::new(
-                        size_info.width.into(),
-                        size_info.height.into(),
+                        size_info.width,
+                        size_info.height,
                         image::ColorType::Rgb8,
                     );
 

--- a/src/lib/scraper/scraper.rs
+++ b/src/lib/scraper/scraper.rs
@@ -73,7 +73,7 @@ pub fn download_issue(
 
     // Check if image directory and any needed formats already exist on disk.
 
-    let mut formats = options.formats;
+    let mut formats = options.formats.clone();
     let exists_already = std::path::Path::new(&issue_pics_dir).exists();
 
     if std::path::Path::new(&filename_pdf).exists() {

--- a/src/lib/scraper/types.rs
+++ b/src/lib/scraper/types.rs
@@ -226,7 +226,7 @@ impl BookMetadata {
             .select(&Selector::parse("#metadata").to_result()?)
             .next()
         {
-            for (i, child) in (0_u32..).zip(e.text()) {
+            for (i, child) in e.text().enumerate() {
                 if i == 0 {
                     publish_date = child.to_string();
                 } else if child.starts_with(Self::PREFIX_PUBLISHER) {

--- a/src/lib/scraper/types.rs
+++ b/src/lib/scraper/types.rs
@@ -139,6 +139,7 @@ pub enum ContentType {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 pub enum DownloadStatus {
     Skipped,
     Complete(BookMetadata),
@@ -176,9 +177,9 @@ impl BookMetadata {
     }
 
     fn parse_length(text: &str) -> io::Result<u32> {
-        Ok(Self::remove_and_extract(text, Self::SUFFIX_PAGES)
+        Self::remove_and_extract(text, Self::SUFFIX_PAGES)
             .parse::<u32>()
-            .to_result()?)
+            .to_result()
     }
 
     fn remove_and_extract(source: &str, to_remove: &str) -> String {
@@ -225,8 +226,7 @@ impl BookMetadata {
             .select(&Selector::parse("#metadata").to_result()?)
             .next()
         {
-            let mut i: u32 = 0;
-            for child in e.text() {
+            for (i, child) in (0_u32..).zip(e.text()) {
                 if i == 0 {
                     publish_date = child.to_string();
                 } else if child.starts_with(Self::PREFIX_PUBLISHER) {
@@ -238,8 +238,6 @@ impl BookMetadata {
                 } else {
                     volume = child.to_string();
                 }
-
-                i += 1;
             }
         };
 

--- a/src/lib/writer/cbz.rs
+++ b/src/lib/writer/cbz.rs
@@ -17,8 +17,10 @@ pub fn create_cbz(image_dir: &str, target_filename: &str) -> io::Result<()> {
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
-    let read_dir = fs::read_dir(image_dir)?;
-    for dir_entry in read_dir.flatten() {
+    let mut entries: Vec<_> = fs::read_dir(image_dir)?
+        .collect::<io::Result<_>>()?;
+    entries.sort_by_key(|e| e.file_name());
+    for dir_entry in entries {
         let mut file = std::fs::File::open(dir_entry.path())?;
         let filename = dir_entry.file_name().into_string().map_err(|file_name| {
             io::Error::new(

--- a/src/lib/writer/cbz.rs
+++ b/src/lib/writer/cbz.rs
@@ -18,18 +18,16 @@ pub fn create_cbz(image_dir: &str, target_filename: &str) -> io::Result<()> {
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     let read_dir = fs::read_dir(image_dir)?;
-    for dir_entry in read_dir {
-        if let Ok(dir_entry) = dir_entry {
-            if let Ok(mut file) = std::fs::File::open(dir_entry.path()) {
-                let filename = dir_entry.file_name().into_string().unwrap();
-                let _ = file.seek(io::SeekFrom::Start(0));
+    for dir_entry in read_dir.flatten() {
+        if let Ok(mut file) = std::fs::File::open(dir_entry.path()) {
+            let filename = dir_entry.file_name().into_string().unwrap();
+            let _ = file.seek(io::SeekFrom::Start(0));
 
-                zip.start_file(filename, options)?;
+            zip.start_file(filename, options)?;
 
-                let mut buffer = Vec::new();
-                let _ = file.read_to_end(&mut buffer)?;
-                zip.write_all(&buffer)?;
-            }
+            let mut buffer = Vec::new();
+            let _ = file.read_to_end(&mut buffer)?;
+            zip.write_all(&buffer)?;
         }
     }
 

--- a/src/lib/writer/cbz.rs
+++ b/src/lib/writer/cbz.rs
@@ -12,7 +12,7 @@ use zip::write::SimpleFileOptions;
 /// * `target_filename` - Path to save CBZ to, including filename and extension.
 pub fn create_cbz(image_dir: &str, target_filename: &str) -> io::Result<()> {
     let dir_entry = std::path::Path::new(target_filename);
-    let file = std::fs::File::create(dir_entry).unwrap();
+    let file = std::fs::File::create(dir_entry)?;
 
     let mut zip = zip::ZipWriter::new(file);
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
@@ -20,13 +20,18 @@ pub fn create_cbz(image_dir: &str, target_filename: &str) -> io::Result<()> {
     let read_dir = fs::read_dir(image_dir)?;
     for dir_entry in read_dir.flatten() {
         if let Ok(mut file) = std::fs::File::open(dir_entry.path()) {
-            let filename = dir_entry.file_name().into_string().unwrap();
-            let _ = file.seek(io::SeekFrom::Start(0));
+            let filename = dir_entry.file_name().into_string().map_err(|file_name| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("image filename is not valid UTF-8: {:?}", file_name),
+                )
+            })?;
+            file.seek(io::SeekFrom::Start(0))?;
 
             zip.start_file(filename, options)?;
 
             let mut buffer = Vec::new();
-            let _ = file.read_to_end(&mut buffer)?;
+            file.read_to_end(&mut buffer)?;
             zip.write_all(&buffer)?;
         }
     }

--- a/src/lib/writer/cbz.rs
+++ b/src/lib/writer/cbz.rs
@@ -19,21 +19,20 @@ pub fn create_cbz(image_dir: &str, target_filename: &str) -> io::Result<()> {
 
     let read_dir = fs::read_dir(image_dir)?;
     for dir_entry in read_dir.flatten() {
-        if let Ok(mut file) = std::fs::File::open(dir_entry.path()) {
-            let filename = dir_entry.file_name().into_string().map_err(|file_name| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("image filename is not valid UTF-8: {:?}", file_name),
-                )
-            })?;
-            file.seek(io::SeekFrom::Start(0))?;
+        let mut file = std::fs::File::open(dir_entry.path())?;
+        let filename = dir_entry.file_name().into_string().map_err(|file_name| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("image filename is not valid UTF-8: {:?}", file_name),
+            )
+        })?;
+        file.seek(io::SeekFrom::Start(0))?;
 
-            zip.start_file(filename, options)?;
+        zip.start_file(filename, options)?;
 
-            let mut buffer = Vec::new();
-            file.read_to_end(&mut buffer)?;
-            zip.write_all(&buffer)?;
-        }
+        let mut buffer = Vec::new();
+        file.read_to_end(&mut buffer)?;
+        zip.write_all(&buffer)?;
     }
 
     zip.finish()?;

--- a/src/lib/writer/pdf.rs
+++ b/src/lib/writer/pdf.rs
@@ -132,21 +132,39 @@ fn create_pdf_internal(
     let mut pages = vec![];
     let paths = fs::read_dir(image_dir)?;
     for p in paths.flatten() {
-        let name = p.file_name().into_string().unwrap();
+        let name = p.file_name().into_string().map_err(|file_name| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("image filename is not valid UTF-8: {:?}", file_name),
+            )
+        })?;
 
-        if let Ok(stream) = lopdf::xobject::image(p.path().as_os_str().to_str().unwrap()) {
+        let image_path = p.path();
+        let image_path_str = image_path.to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("image path is not valid UTF-8: {:?}", image_path),
+            )
+        })?;
+
+        if let Ok(stream) = lopdf::xobject::image(image_path_str) {
             let content = Content {
                 operations: Vec::<Operation>::new(),
             };
-            let content_id =
-                doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+            let encoded_content = content.encode().map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("failed to encode PDF content stream for {}: {e}", name),
+                )
+            })?;
+            let content_id = doc.add_object(Stream::new(dictionary! {}, encoded_content));
 
             let mut width: i64 = 800;
             let mut height: i64 = 1100;
-            if let Object::Integer(a) = stream.dict.get("Width".as_bytes()).unwrap() {
+            if let Some(Object::Integer(a)) = stream.dict.get("Width".as_bytes()) {
                 width = *a;
             }
-            if let Object::Integer(a) = stream.dict.get("Height".as_bytes()).unwrap() {
+            if let Some(Object::Integer(a)) = stream.dict.get("Height".as_bytes()) {
                 height = *a;
             }
 
@@ -157,15 +175,18 @@ fn create_pdf_internal(
                 "MediaBox" => vec![0.into(), 0.into(), width.into(), height.into()],
             });
 
-            let result = doc.insert_image(
+            doc.insert_image(
                 image_filename,
                 stream,
                 (0., 0.),
                 (width as f32, height as f32),
-            );
-            if result.is_err() {
-                println!("error!: {name}")
-            }
+            )
+            .map_err(|err| {
+                io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("failed to insert image '{name}' into PDF: {err}"),
+                )
+            })?;
 
             pages.push(image_filename.into());
 

--- a/src/lib/writer/pdf.rs
+++ b/src/lib/writer/pdf.rs
@@ -28,6 +28,12 @@ impl TocEntry {
     }
 }
 
+impl Default for TableOfContents {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TableOfContents {
     pub fn new() -> TableOfContents {
         TableOfContents {
@@ -125,61 +131,59 @@ fn create_pdf_internal(
     // Add page for each image
     let mut pages = vec![];
     let paths = fs::read_dir(image_dir)?;
-    for path in paths {
-        if let Ok(p) = path {
-            let name = p.file_name().into_string().unwrap();
+    for p in paths.flatten() {
+        let name = p.file_name().into_string().unwrap();
 
-            if let Ok(stream) = lopdf::xobject::image(p.path().as_os_str().to_str().unwrap()) {
-                let content = Content {
-                    operations: Vec::<Operation>::new(),
-                };
-                let content_id =
-                    doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
+        if let Ok(stream) = lopdf::xobject::image(p.path().as_os_str().to_str().unwrap()) {
+            let content = Content {
+                operations: Vec::<Operation>::new(),
+            };
+            let content_id =
+                doc.add_object(Stream::new(dictionary! {}, content.encode().unwrap()));
 
-                let mut width: i64 = 800;
-                let mut height: i64 = 1100;
-                if let Object::Integer(a) = stream.dict.get("Width".as_bytes()).unwrap() {
-                    width = *a;
-                }
-                if let Object::Integer(a) = stream.dict.get("Height".as_bytes()).unwrap() {
-                    height = *a;
-                }
-
-                let image_filename = doc.add_object(dictionary! {
-                    "Type" => "Page",
-                    "Parent" => pages_id,
-                    "Contents" => content_id,
-                    "MediaBox" => vec![0.into(), 0.into(), width.into(), height.into()],
-                });
-
-                let result = doc.insert_image(
-                    image_filename,
-                    stream,
-                    (0., 0.),
-                    (width as f32, height as f32),
-                );
-                if result.is_err() {
-                    println!("error!: {name}")
-                }
-
-                pages.push(image_filename.into());
-
-                // Check for TOC entry for this page
-                if let Some(t) = toc {
-                    if let Some(value) = t.get_page_info(&name) {
-                        let b = Bookmark::new(
-                            value.page_title.clone(),
-                            value.color,
-                            value.format,
-                            image_filename,
-                        );
-                        doc.add_bookmark(b, None);
-                    }
-                }
-
-                //TODO: links in page
-                //Note: may need to download image without setting "w=3000" first in order to scale coordinates
+            let mut width: i64 = 800;
+            let mut height: i64 = 1100;
+            if let Object::Integer(a) = stream.dict.get("Width".as_bytes()).unwrap() {
+                width = *a;
             }
+            if let Object::Integer(a) = stream.dict.get("Height".as_bytes()).unwrap() {
+                height = *a;
+            }
+
+            let image_filename = doc.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Contents" => content_id,
+                "MediaBox" => vec![0.into(), 0.into(), width.into(), height.into()],
+            });
+
+            let result = doc.insert_image(
+                image_filename,
+                stream,
+                (0., 0.),
+                (width as f32, height as f32),
+            );
+            if result.is_err() {
+                println!("error!: {name}")
+            }
+
+            pages.push(image_filename.into());
+
+            // Check for TOC entry for this page
+            if let Some(t) = toc {
+                if let Some(value) = t.get_page_info(&name) {
+                    let b = Bookmark::new(
+                        value.page_title.clone(),
+                        value.color,
+                        value.format,
+                        image_filename,
+                    );
+                    doc.add_bookmark(b, None);
+                }
+            }
+
+            //TODO: links in page
+            //Note: may need to download image without setting "w=3000" first in order to scale coordinates
         }
     }
 

--- a/src/lib/writer/pdf.rs
+++ b/src/lib/writer/pdf.rs
@@ -130,8 +130,10 @@ fn create_pdf_internal(
 
     // Add page for each image
     let mut pages = vec![];
-    let paths = fs::read_dir(image_dir)?;
-    for p in paths.flatten() {
+    let mut entries: Vec<_> = fs::read_dir(image_dir)?
+        .collect::<io::Result<_>>()?;
+    entries.sort_by_key(|e| e.file_name());
+    for p in entries {
         let name = p.file_name().into_string().map_err(|file_name| {
             io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/src/lib/writer/pdf.rs
+++ b/src/lib/writer/pdf.rs
@@ -147,65 +147,66 @@ fn create_pdf_internal(
             )
         })?;
 
-        if let Ok(stream) = lopdf::xobject::image(image_path_str) {
-            let content = Content {
-                operations: Vec::<Operation>::new(),
-            };
-            let encoded_content = content.encode().map_err(|e| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("failed to encode PDF content stream for {}: {e}", name),
-                )
-            })?;
-            let content_id = doc.add_object(Stream::new(dictionary! {}, encoded_content));
-
-            let mut width: i64 = 800;
-            let mut height: i64 = 1100;
-            if let Some(Object::Integer(a)) = stream.dict.get("Width".as_bytes()) {
-                width = *a;
-            }
-            if let Some(Object::Integer(a)) = stream.dict.get("Height".as_bytes()) {
-                height = *a;
-            }
-
-            let image_filename = doc.add_object(dictionary! {
-                "Type" => "Page",
-                "Parent" => pages_id,
-                "Contents" => content_id,
-                "MediaBox" => vec![0.into(), 0.into(), width.into(), height.into()],
-            });
-
-            doc.insert_image(
-                image_filename,
-                stream,
-                (0., 0.),
-                (width as f32, height as f32),
+        let stream = lopdf::xobject::image(image_path_str).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to load image '{}': {e}", name),
             )
-            .map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::Other,
-                    format!("failed to insert image '{name}' into PDF: {err}"),
-                )
-            })?;
+        })?;
+        let content = Content {
+            operations: Vec::<Operation>::new(),
+        };
+        let encoded_content = content.encode().map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("failed to encode PDF content stream for {}: {e}", name),
+            )
+        })?;
+        let content_id = doc.add_object(Stream::new(dictionary! {}, encoded_content));
 
-            pages.push(image_filename.into());
-
-            // Check for TOC entry for this page
-            if let Some(t) = toc {
-                if let Some(value) = t.get_page_info(&name) {
-                    let b = Bookmark::new(
-                        value.page_title.clone(),
-                        value.color,
-                        value.format,
-                        image_filename,
-                    );
-                    doc.add_bookmark(b, None);
-                }
-            }
-
-            //TODO: links in page
-            //Note: may need to download image without setting "w=3000" first in order to scale coordinates
+        let mut width: i64 = 800;
+        let mut height: i64 = 1100;
+        if let Ok(Object::Integer(a)) = stream.dict.get("Width".as_bytes()) {
+            width = *a;
         }
+        if let Ok(Object::Integer(a)) = stream.dict.get("Height".as_bytes()) {
+            height = *a;
+        }
+
+        let image_filename = doc.add_object(dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "Contents" => content_id,
+            "MediaBox" => vec![0.into(), 0.into(), width.into(), height.into()],
+        });
+
+        doc.insert_image(
+            image_filename,
+            stream,
+            (0., 0.),
+            (width as f32, height as f32),
+        )
+        .map_err(|err| {
+            io::Error::other(format!("failed to insert image '{name}' into PDF: {err}"))
+        })?;
+
+        pages.push(image_filename.into());
+
+        // Check for TOC entry for this page
+        if let Some(t) = toc {
+            if let Some(value) = t.get_page_info(&name) {
+                let b = Bookmark::new(
+                    value.page_title.clone(),
+                    value.color,
+                    value.format,
+                    image_filename,
+                );
+                doc.add_bookmark(b, None);
+            }
+        }
+
+        //TODO: links in page
+        //Note: may need to download image without setting "w=3000" first in order to scale coordinates
     }
 
     // Finalize and save document

--- a/src/util/main.rs
+++ b/src/util/main.rs
@@ -89,7 +89,7 @@ impl Args {
                     if std::fs::exists(file)? {
                         for line in std::fs::read_to_string(file).unwrap().lines() {
                             let trimmed = line.trim();
-                            if trimmed != "" {
+                            if !trimmed.is_empty() {
                                 set.insert(trimmed.to_string());
                             }
                         }
@@ -109,7 +109,7 @@ fn main() {
     let mut options = args.to_options().unwrap();
     let result = match args.download_mode {
         DownloadMode::Single => {
-            scraper::download_issue(&args.url, &args.target_dir, &mut options).and_then(|_| Ok(()))
+            scraper::download_issue(&args.url, &args.target_dir, &mut options).map(|_| ())
         }
         DownloadMode::Period => scraper::download_period(&args.url, &args.target_dir, &mut options),
         DownloadMode::Full => scraper::download_all(&args.url, &args.target_dir, &mut options),

--- a/src/util/main.rs
+++ b/src/util/main.rs
@@ -87,7 +87,7 @@ impl Args {
                 let mut set = HashSet::<String>::new();
                 if let Some(file) = self.archive.as_ref() {
                     if std::fs::exists(file)? {
-                        for line in std::fs::read_to_string(file).unwrap().lines() {
+                        for line in std::fs::read_to_string(file)?.lines() {
                             let trimmed = line.trim();
                             if !trimmed.is_empty() {
                                 set.insert(trimmed.to_string());
@@ -106,7 +106,13 @@ impl Args {
 
 fn main() {
     let args = Args::parse();
-    let mut options = args.to_options().unwrap();
+    let mut options = match args.to_options() {
+        Ok(opts) => opts,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    };
     let result = match args.download_mode {
         DownloadMode::Single => {
             scraper::download_issue(&args.url, &args.target_dir, &mut options).map(|_| ())


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on enhanced platform support, dependency updates, code simplification, bug fixes, and robustness improvements identified during code review. The most significant changes include fixing macOS builds by updating the `zip` crate configuration, adding Windows ARM64 build support, improving error handling and code clarity, fixing minor logic issues in the scraper and utility modules, and hardening the CBZ and PDF writers against silent failures and non-deterministic page ordering (Resolves #19).

**Platform and Dependency Updates:**

* Updated the `zip` crate to version 2.2.0, disabled default features, and enabled the `deflate-miniz` feature for more efficient and compatible CBZ/ZIP file creation. This is required for macOS compatibility (`Cargo.toml`).
* Added Windows ARM64 (`aarch64-pc-windows-msvc`) as a build target in the GitHub Actions release workflow, enabling distribution for more Windows devices (`.github/workflows/release.yml`).

**Code Quality and Error Handling Improvements:**

* Replaced deprecated or verbose error creation with the simpler `io::Error::other` and removed redundant doc comments, improving error handling throughout `src/lib/scraper/helpers.rs`. [[1]](src/lib/scraper/helpers.rs) [[2]](src/lib/scraper/helpers.rs)
* Simplified logic for extracting path segments using `.next_back()` instead of `.last()`, simplified `generate_image_filename` to a single `format!` call, and removed a redundant `.to_string()` call on a `Cow<str>`. [[1]](src/lib/scraper/helpers.rs) [[2]](src/lib/scraper/helpers.rs)

**Scraper Logic and Bug Fixes:**

* Removed unnecessary references and clones in function calls and variable assignments, reducing allocations and clarifying intent in `src/lib/scraper/batching.rs` and `src/lib/scraper/scraper.rs`. [[1]](src/lib/scraper/batching.rs) [[2]](src/lib/scraper/batching.rs) [[3]](src/lib/scraper/scraper.rs)
* Fixed logic for skipping pages without download links — the previous code had inverted `None`/`Some` checks that caused pages to be skipped incorrectly. Improved iteration over page children in metadata parsing by replacing a manual counter with `e.text().enumerate()`. [[1]](src/lib/scraper/scraper.rs) [[2]](src/lib/scraper/scraper.rs) [[3]](src/lib/scraper/types.rs)

**Writer Robustness (from code review):**

* Both `create_cbz` (`src/lib/writer/cbz.rs`) and `create_pdf_internal` (`src/lib/writer/pdf.rs`) now collect all `read_dir` entries eagerly via `collect::<io::Result<_>>()?`, propagating any entry-level I/O errors instead of silently dropping them with `.flatten()`.
* Entries are sorted by filename before processing, ensuring stable and deterministic page ordering across all platforms (the zero-padded filename prefix `00001-`, `00002-`, etc. now reliably determines page sequence). [[1]](src/lib/writer/cbz.rs) [[2]](src/lib/writer/pdf.rs)
* `File::open` failures in `create_cbz` now propagate as `io::Error` instead of silently skipping pages, preventing the creation of incomplete archives without any indication of failure. [[1]](src/lib/writer/cbz.rs)
* `lopdf::xobject::image()` failures in `create_pdf_internal` now propagate via `map_err(...)?` instead of being silently skipped via `if let Ok(stream) = ...`, preventing the creation of PDFs with missing pages. [[1]](src/lib/writer/pdf.rs)
* `doc.insert_image()` errors now propagate with a descriptive message via `io::Error::other(...)` instead of printing `"error!: {name}"` and continuing. [[1]](src/lib/writer/pdf.rs)
* `content.encode()`, filename `into_string()`, and path `.to_str()` conversions now return structured `io::Error` instead of panicking via `.unwrap()`. [[1]](src/lib/writer/pdf.rs)

**Utility and Miscellaneous:**

* `args.to_options().unwrap()` in `src/util/main.rs` now matches on the result, printing to stderr and calling `process::exit(1)` on error. `fs::read_to_string(file).unwrap()` is replaced with `?` propagation. [[1]](src/util/main.rs) [[2]](src/util/main.rs)
* Implemented the `Default` trait for `TableOfContents` in `src/lib/writer/pdf.rs` to satisfy Clippy's `new_without_default` lint. [[1]](src/lib/writer/pdf.rs)
* Added `#[allow(clippy::large_enum_variant)]` to `DownloadStatus` and `#[allow(clippy::module_inception)]` to `src/lib/scraper/mod.rs` to suppress relevant Clippy warnings. [[1]](src/lib/scraper/types.rs) [[2]](src/lib/scraper/mod.rs)
* Fixed typos in log messages ("Attemping" → "Attempting") and a comment ("propogation" → "propagation"). [[1]](src/lib/scraper/batching.rs) [[2]](src/lib/scraper/helpers.rs)